### PR TITLE
Update for 4.2 compatibility

### DIFF
--- a/alfresco-folder-quota-repo/src/main/java/org/alfresco/extension/folderquota/behaviour/FolderQuotaBehaviour.java
+++ b/alfresco-folder-quota-repo/src/main/java/org/alfresco/extension/folderquota/behaviour/FolderQuotaBehaviour.java
@@ -23,7 +23,7 @@ import org.alfresco.repo.transaction.AlfrescoTransactionSupport;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.repo.transaction.TransactionListener;
-import org.alfresco.util.transaction.TransactionListenerAdapter;
+import org.alfresco.repo.transaction.TransactionListenerAdapter;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.ContentData;
 import org.alfresco.service.cmr.repository.NodeRef;


### PR DESCRIPTION
Although this method is deprecated, this change is all that is needed in order for this to be compatible with version 4.2.